### PR TITLE
Auth module moved in Django 1.4

### DIFF
--- a/settings.py.template
+++ b/settings.py.template
@@ -152,7 +152,7 @@ TEMPLATE_DIRS = (
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.core.context_processors.auth',
+    'django.contrib.auth.context_processors.auth',
     'django.core.context_processors.debug',
     'django.core.context_processors.i18n',
     'django.core.context_processors.media',


### PR DESCRIPTION
Auth module has moved as of Django1.4, so settings.py needs to change to reflect that else a config error is thrown on all pages. Pip now installs 1.4, so building via requirements.txt causes this issue.

Issue is as here:
http://stackoverflow.com/questions/7470179/module-django-core-context-processors-does-not-define-a-auth-callable-reques
