### PR TITLE
settings: change libgig feed url

### DIFF
--- a/settings.py.template
+++ b/settings.py.template
@@ -231,7 +231,7 @@ USE_THOUSAND_SEPARATOR = True
 JOB_FEEDS = [
     'http://joblist.ala.org/news/',
     'http://archivesgig.livejournal.com/data/atom',
-    'http://www.libgig.com/rss.xml',
+    'http://publicboard.libgig.com/feeds/rss20',
     'http://feeds.feedburner.com/alljobs',
     'http://digital-scholarship.org/digitalkoans/category/digital-library-jobs/feed/',
     'http://www.idealist.org/search/v2/feeds?qs=QlpoOTFBWSZTWROKb4MAAHofgAMIcAIFAAQAv_f_oDAAtjDUJkZGT1GIZMQ0Gk0jZI0NAAeoAxIho0yZTT1A09IGnsaBMZv-SQETKJOFDVQsdpnWDKDuzV4JW8kjKyEyQmjaXJ9RvxmSNJBOdtPsEqMSOOj-u9MR9G0dRMUKrckQVmqWMoGDWxEL3sHHKYZhuzB_w67dyymKrznR2ZVRXUkYvdgHpRe2fJA0X6ksIBkshEdloJ4XuEkfdpnr_F3JFOFCQE4pvgw%3D',


### PR DESCRIPTION
Libgig feed was pulling in blog posts, not jobs
