### PR TITLE
Open origin URL in a new window/tab

### DIFF
--- a/jobs/templates/job_edit.html
+++ b/jobs/templates/job_edit.html
@@ -86,7 +86,7 @@
             <dd><input placeholder="joan@example.edu" type="text" name="contact_email" value="{{ job.contact_email }}"></input></dd>
             {% if job.origin_url %}
             <dt>Origin URL:</dt>
-            <dd><a href="{{ job.origin_url }}">{{ job.origin_url|urlizetrunc:40 }}</a></dd>
+            <dd><a href="{{ job.origin_url }}" target="_blank">{{ job.origin_url|urlizetrunc:40 }}</a></dd>
             {% endif %}
             <dt itempropr="url">Job URL:</dt>
             <dd><input placeholder="http://example.edu/jobs/1234/" type="url" name="url" value="{{ job.url }}"></input></dd>


### PR DESCRIPTION
In any case I can think of, I'd want the original job announcement opened in a new window/tab when editing so I can copy and paste in from that page.
