### PR TITLE
update email footer

### DIFF
--- a/jobs/models.py
+++ b/jobs/models.py
@@ -206,6 +206,7 @@ class Job(models.Model):
         body += self.location.name + "\r\n\r\n"
         body += html2text.html2text(self.description)
         body += "\r\n\r\nBrought to you by code4lib jobs: " + url
+        body += "\r\nTo post a new job please visit http://jobs.code4lib.org/"
         body = re.sub('&[^ ]+;', '', body)
 
         if self.employer:


### PR DESCRIPTION
added a sentence so folks know they can go to jobs.code4lib.org and post jobs there.  i _think_ folks can also email jobs@code4lib.org, but since i'm not 100% certain, i don't want to include that here (hint, hint for someone more in the know).
