### PR TITLE
Add missing pytz dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ html2text==3.200.3
 MySQL-python==1.2.4c1
 nltk==2.0.4
 numpy==1.6.2
+pytz==2016.4
 requests==0.14.2
 South==0.7.6
 tweepy==2.0


### PR DESCRIPTION
Without this, for me I get `ImportError: No module named pytz` when trying to run `manage.py` after `pip install -r requirements.txt`.