### PR TITLE
Fix syntax for running migrations from scratch

### DIFF
--- a/jobs/migrations/0025_populate_locations.py
+++ b/jobs/migrations/0025_populate_locations.py
@@ -7,9 +7,7 @@ from django.db import models
 class Migration(DataMigration):
 
     def forwards(self, orm):
-        from shortimer.jobs.models import Job, Employer
-
-        for employer in Employer.objects.filter(city='', freebase_id__isnull=False):
+        for employer in orm.Employer.objects.filter(city='', freebase_id__isnull=False):
             employer.load_freebase_data()
             employer.save()
             print employer.slug.encode("utf-8")


### PR DESCRIPTION
Without this, I get `Error in migration: jobs:0025_populate_locations` when I run `python manage.py syncdb --migrate --noinput`. I believe this fixes it because `orm.` will cause the forwards migration to use the model at the time this migration was created, rather than the latest model we get if we use `from shortimer.jobs.models import Job, Employer` (see: http://django-south.readthedocs.io/en/latest/tutorial/part3.html).
